### PR TITLE
fwupdate-signed -> fwupd-signed

### DIFF
--- a/live-common
+++ b/live-common
@@ -15,7 +15,7 @@ Ubiquity needs full filesystem support for the partitioner.
 
 # * (bootchart) [!armel] # scheduled for removal before maverick beta
 
- * fwupdate-signed #signed efi firmware updating executable, remove in ubiquity if !efi
+ * fwupd-signed #signed efi firmware updating executable, remove in ubiquity if !efi
 
  * mokutil [amd64] # Needed for EFI install with third-party drivers
 


### PR DESCRIPTION
`fwupdate-signed` doesn't exist anymore in `focal`

To match the upstream commit: https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/platform/commit/?h=focal&id=205a3d172f721e6a5ce76723a4cd0e4437a4d8c3